### PR TITLE
Fixed: Use fasthttp.Client instead of fasthttp.HostClient

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -21,7 +21,7 @@ import (
 type cacheServer struct {
 	cache             ybc.Cacher
 	stats             Stats
-	upstreamClient    *fasthttp.HostClient
+	upstreamClient    *fasthttp.Client
 	logger            *log.Logger
 	upstreamHostBytes []byte
 	keyPool           sync.Pool
@@ -31,13 +31,9 @@ type cacheServer struct {
 // NewCacheServer returns a new instance of a cache server.
 func NewCacheServer(l *log.Logger) *cacheServer {
 	c := &cacheServer{
-		cache: createCache(l),
-		upstreamClient: &fasthttp.HostClient{
-			Addr:     *upstreamHost,
-			MaxConns: *maxIdleUpstreamConns,
-		},
-		upstreamHostBytes: []byte(*upstreamHost),
-		logger:            l,
+		cache:          createCache(l),
+		upstreamClient: &fasthttp.Client{},
+		logger:         l,
 	}
 	return c
 }
@@ -201,7 +197,7 @@ func (cs *cacheServer) requestHandler(ctx *fasthttp.RequestCtx) {
 		var resp fasthttp.Response
 		err := cs.upstreamClient.Do(&req, &resp)
 		if err != nil {
-			cs.logRequestError(h, "Cannot make request for [%s]: [%s]", ctx.RequestURI(), err)
+			cs.logRequestError(h, "Cannot make request for [%s]: [%s]", upstreamURL, err)
 			return
 		}
 

--- a/config.ini
+++ b/config.ini
@@ -6,9 +6,6 @@ cacheFilesPath = ./cache # Path to cache file. Leave empty for anonymous non-per
     # and each cache file is located on a distinct physical storage.
 cacheSize = 1000  # The total cache size in Mbytes
 configUpdateInterval = 0s  # Update interval for re-reading config file set via -config flag. Zero disables config file re-reading.
-httpsCertFile = /etc/ssl/certs/ssl-cert-snakeoil.pem  # Path to HTTPS server certificate. Used only if listenHttpsAddr is set
-httpsKeyFile = /etc/ssl/private/ssl-cert-snakeoil.key  # Path to HTTPS server key. Used only if listenHttpsAddr is set
-httpsListenAddr =   # A list of TCP addresses to listen to HTTPS requests. Leave empty if you don't need https
 listenAddr = :8098  # A list of TCP addresses to listen to HTTP requests. Leave empty if you don't need http
 maxIdleUpstreamConns = 50  # The maximum idle connections to upstream host
 maxItemsCount = 100000  # The maximum number of items in the cache

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 allowMissingConfig = false  # Don't terminate the app if the ini file cannot be read.
 allowUnknownFlags = false  # Don't terminate the app if ini file contains unknown flags.
-cacheFilesPath = # Path to cache file. Leave empty for anonymous non-persistent cache.
+cacheFilesPath = ./cache # Path to cache file. Leave empty for anonymous non-persistent cache.
     # Enumerate multiple files delimited by comma for creating a cluster of caches.
     # This can increase performance only if frequently accessed items don't fit RAM
     # and each cache file is located on a distinct physical storage.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/agnivade/mdns v0.0.0-20190517090340-7842cff488c8
+	github.com/micro/mdns v0.1.0
 	github.com/valyala/fasthttp v1.2.0
 	github.com/valyala/ybc v0.0.0-20181207142156-3d480539f84d
 	github.com/vharitonsky/iniflags v0.0.0-20180513140207-a33cd0b5f3de

--- a/main.go
+++ b/main.go
@@ -26,9 +26,6 @@ var (
 			"This can increase performance only if frequently accessed items don't fit RAM\n"+
 			"and each cache file is located on a distinct physical storage.")
 	cacheSize            = flag.Int("cacheSize", 100, "The total cache size in Mbytes")
-	httpsCertFile        = flag.String("httpsCertFile", "/etc/ssl/certs/ssl-cert-snakeoil.pem", "Path to HTTPS server certificate. Used only if listenHttpsAddr is set")
-	httpsKeyFile         = flag.String("httpsKeyFile", "/etc/ssl/private/ssl-cert-snakeoil.key", "Path to HTTPS server key. Used only if listenHttpsAddr is set")
-	httpsListenAddr      = flag.String("httpsListenAddr", "", "TCP address to listen to HTTPS requests. Leave empty if you don't need https")
 	listenAddr           = flag.String("listenAddr", ":8098", "TCP address to listen to HTTP requests. Leave empty if you don't need http")
 	maxIdleUpstreamConns = flag.Int("maxIdleUpstreamConns", 50, "The maximum idle connections to upstream host")
 	maxItemsCount        = flag.Int("maxItemsCount", 100*1000, "The maximum number of items in the cache")


### PR DESCRIPTION
The HostClient always points to a fixed Host. But we just need to Client
to point to multiple hosts and get the response.